### PR TITLE
ensure relationships don’t break linter

### DIFF
--- a/src/Linters/PreferAuthId.php
+++ b/src/Linters/PreferAuthId.php
@@ -19,7 +19,7 @@ class PreferAuthId extends MatchingLinter
 	{
 		return $this->treeMatcher()
 			->withChild(function(MemberAccessExpression $node) {
-				return Str::endsWith($node->getText(), '->id');
+				return Str::endsWith($node->getText(), '::user()->id');
 			})
 			->withChild(function(CallExpression $node) {
 				return Str::endsWith($node->callableExpression->getText(), '::user');

--- a/tests/Linters/PreferAuthIdTest.php
+++ b/tests/Linters/PreferAuthIdTest.php
@@ -55,12 +55,15 @@ class PreferAuthIdTest extends TestCase
 	
 	public function test_it_does_not_flag_similar_looking_signatures() : void
 	{
-		$source = <<<'END_SOURCE'
-		$id = API::user()->id;
-		END_SOURCE;
-		
-		$this->withLinter(PreferAuthId::class)
-			->lintSource($source)
-			->assertNoLintingResults();
+		$sources = [
+			'$id = API::user()->id',
+			'$id = Auth::user()->relationship->id',
+		];
+
+		foreach($sources as $source) {
+			$this->withLinter(PreferAuthId::class)
+				->lintSource($source)
+				->assertNoLintingResults();
+		}
 	}
 }


### PR DESCRIPTION
I ran into an issue where I was calling `Auth::user()->someRelationship()->id` and the rule `PreferAuthId` rule was being triggered.