### PR TITLE
Fix enum usage error

### DIFF
--- a/src/Linters/OrderClassMembers.php
+++ b/src/Linters/OrderClassMembers.php
@@ -115,6 +115,7 @@ class OrderClassMembers extends OrderingLinter
 				->withChild(function(MethodDeclaration $node) {
 					return $this->isPublic($node)
 						&& $this->isStatic($node)
+						&& property_exists($this->currentContext(), 'data_providers')
 						&& ! $this->currentContext()->data_providers->contains($node->getName());
 				}),
 			

--- a/tests/Linters/OrderClassMembersTest.php
+++ b/tests/Linters/OrderClassMembersTest.php
@@ -69,7 +69,26 @@ class OrderClassMembersTest extends TestCase
 			->lintSource($source)
 			->assertNoLintingResults();
 	}
-	
+
+	public function test_it_allows_enums() : void
+	{
+		$source = <<<'END_SOURCE'
+		enum Foo: string
+		{
+			case bar = 'bar';
+
+			public static function staticFoo()
+			{
+				return static::$static_foo;
+			}
+		}
+		END_SOURCE;
+
+		$this->withLinter(OrderClassMembers::class)
+			->lintSource($source)
+			->assertNoLintingResults();
+	}
+
 	public function test_it_gives_special_consideration_to_setUp_and_tearDown_methods_in_tests() : void
 	{
 		$source = <<<'END_SOURCE'


### PR DESCRIPTION
I was getting an error when laralint was run on a backed enum.

```shell

   _                        _
 _|_)                    \_|_)  o
  |     __,   ,_    __,    |        _  _  _|_
 _|    /  |  /  |  /  |   _|    |  / |/ |  |
 /\___/\_/|_/   |_/\_/|_/(/\___/|_/  |  |_/|_/


some/directory/MySpecialEnum.php
----------------------------------------------

ErrorException {#9213
  #message: "Undefined property: stdClass::$data_providers"
  #code: 0
  #file: "./vendor/glhd/laralint/src/Linters/OrderClassMembers.php"
  #line: 118
  #severity: E_WARNING
  trace: {
    ./vendor/glhd/laralint/src/Linters/OrderClassMembers.php:118 { …}
    ./vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:256 { …}
    ./vendor/glhd/laralint/src/Linters/OrderClassMembers.php:118 { …}
    ./vendor/glhd/laralint/src/Linters/Matchers/TreeMatcher.php:139 { …}
    Glhd\LaraLint\Linters\Matchers\TreeMatcher->Glhd\LaraLint\Linters\Matchers\{closure}() {}
    ./vendor/glhd/laralint/src/Linters/Matchers/TreeMatcher.php:99 { …}
    ./vendor/glhd/laralint/src/Linters/Matchers/TreeMatcher.php:49 { …}
    ./vendor/glhd/laralint/src/Linters/Matchers/FirstMatchAggregateMatcher.php:54 { …}
    ./vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php:257 { …}
    ./vendor/glhd/laralint/src/Linters/Matchers/FirstMatchAggregateMatcher.php:47 { …}
    ./vendor/glhd/laralint/src/Linters/Strategies/OrderingLinter.php:58 { …}
    ./vendor/glhd/laralint/src/Linters/OrderClassMembers.php:27 { …}
    ./vendor/glhd/laralint/src/Runners/SourceCodeRunner.php:67 { …}
    ./vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php:257 { …}
    ./vendor/glhd/laralint/src/Runners/SourceCodeRunner.php:65 { …}
    ./vendor/glhd/laralint/src/Runners/SourceCodeRunner.php:71 { …}
    ./vendor/glhd/laralint/src/Runners/SourceCodeRunner.php:71 { …}
    ./vendor/glhd/laralint/src/Runners/SourceCodeRunner.php:32 { …}
    ./vendor/glhd/laralint/src/Commands/LintCommand.php:61 { …}
    ./vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php:257 { …}
    ./vendor/glhd/laralint/src/Commands/LintCommand.php:58 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/Util.php:43 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:95 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:35 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/Container.php:690 { …}
    ./vendor/laravel/framework/src/Illuminate/Console/Command.php:213 { …}
    ./vendor/symfony/console/Command/Command.php:279 { …}
    ./vendor/laravel/framework/src/Illuminate/Console/Command.php:182 { …}
    ./vendor/symfony/console/Application.php:1047 { …}
    ./vendor/symfony/console/Application.php:316 { …}
    ./vendor/symfony/console/Application.php:167 { …}
    ./vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:197 { …}
    ./artisan:35 {
      › 
      › $status = $kernel->handle(
      › \t$input = new Symfony\Component\Console\Input\ArgvInput(),
      arguments: {
        $input: Symfony\Component\Console\Input\ArgvInput {#33 …}
        $output: Symfony\Component\Console\Output\ConsoleOutput {#31 …}
      }
    }
  }
}